### PR TITLE
v1.0.3 - Added times

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Godo is a modern, Make‑inspired task runner, designed to make your build and a
 ## Features
 
 - **`where`**: Execute commands from any subdirectory, without manual `cd` steps.
+- **`times`**: Execute commands any amount of times in a loop.
 - **`variants`**: Define OS‑ or environment‑specific command variants (based on `GOOS`).
 - **`description`**: Provide human‑readable explanations for each task.
 - **Fallback Help**: Running `godo` with no arguments lists all available tasks and their descriptions.
@@ -50,6 +51,7 @@ Each task under `commands:` can include:
 
 - **`run`** *(array of strings)*: One or more shell commands executed in sequence.  
 - **`where`** *(string)*: Relative path to the directory where commands run (defaults to project root).  
+- **`times`** *(int)*: Defualt is 1. Runs all the commands in the run field x amount of times, works for variants as well.  
 - **`type`** *(string)*: Execution mode (`raw`, `shell`, or `path`). Usually, the default is sufficient.  
 - **`description`** *(string)*: A short description for `godo`’s help output.  
 - **`variants`** *(array)*: Platform or environment–specific overrides (ignores `run` at the root):
@@ -73,7 +75,7 @@ Ensure `$GOPATH/bin` (or `$GOBIN`) is in your `PATH`.
 
 - Run `godo` to list all tasks and descriptions.
 - Execute a task: `godo <task-name>` (e.g., `godo test`).
-- Combine complex workflows by breaking them into smaller, reusable `godo` tasks.
+- Combine complex workflows by breaking them into smaller, reusable `godo` tasks, also great for loops.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/VincentBrodin/godo
 
-go 1.24.0
+go 1.24.3
 
 require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // direct
@@ -18,4 +18,7 @@ require (
 	golang.org/x/sys v0.17.0 // indirect
 )
 
-require github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+require (
+	github.com/VincentBrodin/suddig v0.0.0-20250508204840-870ec81c7636
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/VincentBrodin/suddig v0.0.0-20250508204840-870ec81c7636 h1:19E9JQplcZ22jDXmV6K9nDte8Gp++I1n0geX5nxpBYU=
+github.com/VincentBrodin/suddig v0.0.0-20250508204840-870ec81c7636/go.mod h1:OyHD1WgJrW5gr+LylunLtB7VdxESFUAWdksuT+uakww=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=

--- a/godo.yml
+++ b/godo.yml
@@ -1,4 +1,9 @@
 commands:
+  loop:
+    run: echo "Hello world"
+    times: 10
+    description: "Runs command 10 times"
+  
   install:
     run: go install ./...
     description: Installs godo from your local source code

--- a/godo.yml
+++ b/godo.yml
@@ -9,7 +9,7 @@ commands:
     description: Installs godo from your local source code
   fail:
     run: 
-      - $a
+      - a
       - $b
       - echo Works
     description: This code will fail twice

--- a/init.go
+++ b/init.go
@@ -1,12 +1,13 @@
-commands:
+package main
+					
+const Init = 
+`commands:
+
   loop:
     run: echo "Hello world"
     times: 10
     description: "Runs command 10 times"
-  
-  install:
-    run: go install ./...
-    description: Installs godo from your local source code
+
   fail:
     run: 
       - a
@@ -14,21 +15,7 @@ commands:
       - echo Works
     description: This code will fail twice
 
-  test:
-    run: 
-      - go clean -testcache
-      - go test ./...
-    description: Runs all the test
-
-  testv:
-    run: 
-      - go clean -testcache
-      - go test ./... -v
-    description: Runs all the test in verbose mode
-
-
-  os: # Variants allow os indipendent commands to be ran the platform is based on GOOS. 
-      # Here is a list of possible GOOS: https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63
+  os:    
     variants:
       - run: echo Windows
         platform: windows
@@ -37,7 +24,6 @@ commands:
       - run: echo Unkown
         platform: defualt
     description: Tells you what os you are running
-
 
 # A command can have these values
 # run - one or more commands that will run in the given order
@@ -48,5 +34,4 @@ commands:
 # variants - allows for better control over how commands are ran in different enviroments 
 #     variants can have these values
 #       run - the same as commands run (if the command has run commands the variants will be ignored)
-#       platform - can be any value that is in GOOS or defualt
-#       type - the same as commands type
+#       platform - can be any value that is in GOOS or defualt`

--- a/main.go
+++ b/main.go
@@ -8,10 +8,12 @@ import (
 	"github.com/VincentBrodin/godo/pkg/engine"
 	"github.com/VincentBrodin/godo/pkg/parser"
 	"github.com/VincentBrodin/godo/pkg/utils"
+	"github.com/VincentBrodin/suddig/matcher"
+
+	"slices"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"slices"
 )
 
 func main() {
@@ -75,7 +77,11 @@ func listCommands(godoFile *parser.GodoFile) {
 	prompt := promptui.Select{
 		Label: "Select command",
 		Searcher: func(input string, index int) bool {
-			return strings.HasPrefix(keys[index], input)
+			c := matcher.DefualtConfig()
+			c.MinScore = 0.5
+			c.StringFunc = func(s string) string { return strings.ToLower(s) }
+			m := matcher.New(c)
+			return m.Match(input, keys[index]) || strings.HasPrefix(keys[index], input)
 		},
 		Size:  len(keys),
 		Items: keys,

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/VincentBrodin/godo/pkg/parser"
 )
@@ -13,6 +14,23 @@ func Run(cmd parser.Command) error {
 		return err
 	}
 
+	if resCmd.Times == 1 {
+		if err := run(resCmd); err != nil {
+			return err
+		}
+	} else {
+		for i := range resCmd.Times {
+			log.Printf("Running %d of %d\n", i+1, resCmd.Times)
+			if err := run(resCmd); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func run(resCmd ResolvedCommand) error {
 	switch resCmd.Type {
 	case "raw":
 		if err := runRaw(resCmd); err != nil {
@@ -29,6 +47,5 @@ func Run(cmd parser.Command) error {
 	default:
 		return fmt.Errorf("Unkown run type: %s. Only allows: 'raw','path' or 'shell' (defualt 'shell')\n", resCmd.Type)
 	}
-
 	return nil
 }

--- a/pkg/engine/resolver.go
+++ b/pkg/engine/resolver.go
@@ -7,6 +7,7 @@ import (
 
 type ResolvedCommand struct {
 	Run   []string
+	Times int32
 	Where string
 	Type  string
 }
@@ -29,8 +30,14 @@ func resolve(cmd parser.Command) (ResolvedCommand, error) {
 		t = *_t
 	}
 
+	var times int32 = 1
+	if cmd.Times != nil {
+		times = *cmd.Times
+	} 
+
 	return ResolvedCommand{
 		Run:   run,
+		Times: times,
 		Where: where,
 		Type:  t,
 	}, nil

--- a/pkg/engine/runners.go
+++ b/pkg/engine/runners.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -39,9 +40,9 @@ func runShell(resCmd ResolvedCommand) error {
 		cmd.Stderr = os.Stderr
 		cmd.Dir = resCmd.Where
 
-		if err := cmd.Run(); err != nil{
+		if err := runCmd(cmd); err != nil {
 			if canFail {
-				log.Printf("%s failed but will keep running: %v", run, err)
+				log.Printf("Got an error running '%s', but will keep running: %v\n", run, err)
 			} else {
 				return err
 			}
@@ -84,9 +85,9 @@ func runPath(resCmd ResolvedCommand) error {
 		cmd.Stderr = os.Stderr
 		cmd.Dir = resCmd.Where
 
-		if err := cmd.Run(); err != nil{
+		if err := runCmd(cmd); err != nil {
 			if canFail {
-				log.Printf("%s failed but will keep running: %v", run, err)
+				log.Printf("Got an error running '%s', but will keep running: %v\n", run, err)
 			} else {
 				return err
 			}
@@ -104,7 +105,6 @@ func runRaw(resCmd ResolvedCommand) error {
 		if len(run) == 0 {
 			continue
 		}
-		// Check if is banglines
 		run, canFail := utils.CanFail(run)
 
 		if canFail {
@@ -124,14 +124,24 @@ func runRaw(resCmd ResolvedCommand) error {
 		cmd.Stderr = os.Stderr
 		cmd.Dir = resCmd.Where
 
-		if err := cmd.Run(); err != nil{
+		if err := runCmd(cmd); err != nil {
 			if canFail {
-				log.Printf("%s failed but will keep running: %v", run, err)
+				log.Printf("Got an error running '%s', but will keep running: %v\n", run, err)
 			} else {
 				return err
 			}
 		}
 
 	}
+	return nil
+}
+
+func runCmd(cmd *exec.Cmd) error {
+	if err := cmd.Run(); err != nil {
+		return err
+	} else if exit := cmd.ProcessState.ExitCode(); exit != 0 {
+		return fmt.Errorf("Exited with status code %d\n", exit)
+	}
+
 	return nil
 }

--- a/pkg/parser/godofile.go
+++ b/pkg/parser/godofile.go
@@ -13,6 +13,7 @@ type GodoFile struct {
 type Command struct {
 	Run         *Run      `yaml:"run"`
 	Where       *string   `yaml:"where"`
+	Times       *int32    `yaml:"times"`
 	Type        *string   `yaml:"type"`
 	Description *string   `yaml:"description"`
 	Variants    []Variant `yaml:"variants"`


### PR DESCRIPTION
In version 1.0.3 of godo, the `times` value can now be set. The `times` value allows any godo command to be run a specified number of times. Recursive godo commands that fail will now return their failure code to the parent command. The `init` command now bootstraps a starter godo file when none exists in the current directory.
